### PR TITLE
Teams notification resource for concourse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7-alpine
+ENV PACKAGES "bash curl openssl ca-certificates jq vim"
+RUN apk add --update "${PACKAGES}" && rm -rf /var/cache/apk/*
+RUN pip install --upgrade pip
+COPY assets/ /opt/resource/
+RUN pip install -r /opt/resource/requirements.txt
+RUN chmod +x /opt/resource/*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,85 @@
-# concourse-teams-notification-resource
-Concourse 'Microsoft Teams' notification resource
+Concourse Teams Notification Resource
+==================
+
+Sends alerts to Teams.
+This resource can now send log output of failing Concourse task(s) to Teams.
+
+Resource Type Configuration
+---------------------------
+
+```yml
+resource_types:
+- name: teams-notification
+  type: docker-image
+  source:
+    repository: fidelityinternational/concourse-teams-resource
+    tag: latest
+```
+
+Source Configuration
+--------------------
+
+The following fields are required if you want to see erroring Concourse task output in the Teams notification:
+
+- atc_external_url: *Optional* The ATC external URL (if username and password is supplied but not the ATC URL, it will attempt to use the standard in-built ATC_EXTERNAL_URL instead)
+- atc_username: *Optional* ATC username is required if atc_external_url is supplied.
+- atc_password: *Optional* ATC password is required if atc_external_url is supplied.
+
+Example resource config:
+
+```yml
+resources:
+- name: teams-alert
+  type: teams-notification
+  source:
+    url: ((teams_webhook))
+    atc_username: ...
+    atc_password: ...
+```
+
+Behaviour
+--------
+
+### Sends alert to teams.
+
+Send alert to teams with the configured parameters.
+
+#### Parameters
+
+Required:
+
+- `status`: 'failure' or 'success' for whether resource is called under on_failure or on_success.
+
+Example
+-------
+
+```yml
+on_failure: # or on_success:
+        do:
+        - put: teams-alert
+          params:
+            status: failure #or status: success
+```
+
+See our sample [test-pipeline.yml](test-pipeline.yml) for a working example.
+
+Testing
+-------
+
+To test this resource, either:
+
+1. Using test-pipeline, add resource, resource type, and on_failure/on_success examples to an existing pipeline, or
+
+2. install a test Concourse with Docker.
+
+Push the sample pipeline to it (remember to update the Teams resource configuration options first, as appropriate):
+
+``` sh
+fly login -t local -c http://localhost:8080 -u <local-username> -p <local-password>
+fly -t local set-pipeline -p test -c test-pipeline.yml
+```
+
+Browse http://localhost:8080 and run the monitoring-test job. One of the tasks in that job is supposed to succeed, and one is supposed to fail. Note the Teams put: on the failing job. This should now trigger, so check Teams for an incoming alert.
+
+Inside the alert message you should find pipeline, job_name, concourse_build_url and output fields which contain the logs from failed or succeeded jobs.
+>>>>>>> 9ac5c11... Teams notification resource for concourse

--- a/assets/check
+++ b/assets/check
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "[]"

--- a/assets/in
+++ b/assets/in
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo '{"version":{"ref":"none"}}'

--- a/assets/out
+++ b/assets/out
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -eu
+
+exec 3>&1 # make stdout available as fd 3 for the result
+exec 1>&2 # redirect all output to stderr for logging
+
+# for jq
+PATH=/usr/local/bin:$PATH
+
+payload=$(mktemp /tmp/resource-in.XXXXXX)
+
+cat > "${payload}" <&0
+
+webhook_url="$(jq -r '.source.url' < "${payload}")"
+build_status="$(jq -r '(.params.status // null)' < "${payload}")"
+proxy="$(jq -r '(.params.proxy // null)' < "${payload}")"
+atc_username="$(jq -r '.source.atc_username' < "${payload}")"
+atc_password="$(jq -r '.source.atc_password' < "${payload}")"
+region=$(echo "${ATC_EXTERNAL_URL}" | cut -d'.' -f2)
+concourse_hostname=$(echo "${ATC_EXTERNAL_URL}" | cut -d'.' -f1 | sed -e 's/https:\/\///g')
+
+if [ "${webhook_url}" == "" ]; then
+  echo "No webhook_url has been set. Exiting.."
+  exit 1
+fi
+
+if [[ "${proxy}" == "false" ]]; then
+  unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+fi
+
+if [ "${ATC_EXTERNAL_URL:-}" != "" ] && [ "${atc_username:-}" != "" ] && [ "${atc_password:-}" != "" ]; then
+    error_context="$(python /opt/resource/teams_error_capture.py \
+    "${ATC_EXTERNAL_URL}" \
+    "${atc_username}" \
+    "${atc_password}" \
+    "${BUILD_ID}")"
+else
+    error_context="No error context possible without valid ATC url and credentials."
+fi
+
+case "$build_status" in
+  success)
+    message_color='00FF00'
+    message_title="Build ${BUILD_PIPELINE_NAME} - ${BUILD_JOB_NAME} - ${region} - ${concourse_hostname} succeeded"
+    ;;
+  failure)
+    message_color='FF0000'
+    message_title="Build ${BUILD_PIPELINE_NAME} - ${BUILD_JOB_NAME} - ${region} - ${concourse_hostname} failed"
+    ;;
+  *)
+    echo "Neither success nor failure was set as the build_status. Exiting.."
+    exit 1
+    ;;
+esac
+
+
+message_summary="${BUILD_PIPELINE_NAME} - ${BUILD_JOB_NAME}"
+message_title_link="${ATC_EXTERNAL_URL}/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}"
+
+body="$(cat <<EOF
+{
+	"@type": "MessageCard",
+	"@context": "https://schema.org/extensions",
+	"summary": "${message_summary}",
+	"themeColor": "${message_color}",
+	"title": "${message_title}",
+	"potentialAction": [
+		{
+			"@type": "OpenUri",
+			"name": "View in Concourse",
+			"targets": [
+				{
+					"os": "default",
+					"uri": "${message_title_link}"
+				}
+			]
+		}
+	],
+  	"sections": [
+      {
+        "text": ${error_context}
+      }
+  	]
+}
+EOF
+)"
+
+compact_body="$(echo "${body}" | jq -c '.')"
+
+curl -f -s -L -X POST \
+  "${webhook_url}" \
+  -H 'Content-Type: application/json' \
+  -H 'cache-control: no-cache' \
+  -d "${compact_body}"
+
+# print the output
+
+timestamp="$(jq -n "{version:{time:\"$(date --utc +%FT%T.%3NZ)\"}}")"
+echo "$timestamp" | jq -s add >&3

--- a/assets/requirements.txt
+++ b/assets/requirements.txt
@@ -1,0 +1,3 @@
+urllib3
+sseclient-py
+requests

--- a/assets/teams_error_capture.py
+++ b/assets/teams_error_capture.py
@@ -1,0 +1,110 @@
+import json, requests, sseclient, sys, urllib3
+
+def search_ids_names(current_id, accum_dict, plan):
+    if 'id' in plan:
+        current_id = plan['id']
+    if 'name' in plan:
+        accum_dict[current_id] = plan['name']
+
+    for v in list(plan.values()):
+        if type(v) == dict:
+            search_ids_names(current_id, accum_dict, v)
+        if type(v) == list:
+            for v2 in v:
+                search_ids_names(current_id, accum_dict, v2)
+
+    return accum_dict
+
+def main(): 
+    requests.packages.urllib3.disable_warnings()
+
+    # variables are env vars from a 'get' or 'put' concourse container
+    concourse_hostname = sys.argv[1] 
+    concourse_username = sys.argv[2]
+    concourse_password = sys.argv[3]
+    build_number = sys.argv[4]
+
+    # Login
+    # OAuth2 token request
+    url = '{0}/sky/token'.format(concourse_hostname)
+    payload = {
+      'grant_type': 'password',
+      'username': concourse_username,
+      'password': concourse_password,
+      'scope': 'openid profile email federated:id groups'
+    }
+
+    response = requests.post(url, verify=False, data=payload, auth=('fly', 'Zmx5'))
+
+    if response.status_code != 200:
+        print(("Login failed (status: {0}). Exiting.").format(response.status_code))
+        sys.exit(1)
+
+    token = json.loads(response.content)['access_token']
+
+    # Resolve taskid's to names
+    url = '{0}/api/v1/builds/{1}/plan'.format(concourse_hostname, build_number)
+    headers = {
+        'Authorization': 'Bearer {0}'.format(token)
+    }
+    response = requests.get(url, verify=False, headers=headers)
+
+    if response.status_code != 200:
+        print(("Login (when supplying token to get plan) failed (status: {0}). Exiting.").format(response.status_code))
+        sys.exit(1)
+
+    plan = json.loads(response.content)
+    task_map = search_ids_names(None, {}, plan)
+
+    # Job event stream
+    url = '{0}/api/v1/builds/{1}/events'.format(concourse_hostname, build_number)
+    headers = {
+        'Authorization': 'Bearer {0}'.format(token),
+        'Accept': 'text/event-stream'
+    }
+
+    response = requests.get(url, verify=False, headers=headers, stream=True)
+
+    if response.status_code != 200:
+        print(("Job failed but unable to fetch event stream (status: {0}). Exiting.").format(response.status_code))
+        sys.exit(1)
+
+    client = sseclient.SSEClient(response)
+
+    logs = {}
+
+    # This line identifies we are reading output stream from task id where teams notification runs. There is no way to get current task ID so 'EventReaderWaterMark' acts as a pointer so the script knows not to record its own logs (gets stuck in a loop when it does)
+    resourceTaskId = None
+    sys.stderr.write("EventReaderWaterMark: Retrieving event log from concourse\n")
+    sys.stderr.flush()
+
+    try:
+        output = ""
+        for event in client.events():
+            if event.event == 'end':
+                break
+
+            edata = json.loads(event.data)
+            if edata['event'] == "finish-task" and edata['data']['exit_status'] == 0:
+                taskId = edata['data']['origin']['id']
+                logs.pop(taskId, None)
+
+            if edata['event'] == "log":
+                taskId = edata['data']['origin']['id']
+                logs[taskId] = logs.get(taskId, "") + edata['data']['payload']
+                if edata['data']['payload'].startswith("EventReaderWaterMark:"):
+                    resourceTaskId = taskId
+                    break
+
+    except requests.exceptions.Timeout as e:
+      pass
+
+    if resourceTaskId:
+      logs.pop(resourceTaskId, None)
+
+# messagecards for teams require \n\n for a new line
+    output=("\n").join("\n--------------\n".join([task_map[k], v]) for k,v in list(logs.items()))
+    print(json.dumps(output.replace("\n","\n\n")))
+
+if __name__ == '__main__':
+    main()

--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -1,0 +1,66 @@
+---
+resource_types:
+- name: teams-notification
+  type: docker-image
+  source:
+    repository: fidelityinternational/concourse-teams-notification-resource
+    tag: latest
+
+resources:
+- name: teams-alert
+  type: teams-notification
+  source:
+    webhook_url: <webhook>
+    concourse_username: <username>
+    concourse_password: <password>
+
+jobs:
+- name: monitoring-test
+  serial: true
+  build_logs_to_retain: 20
+  plan:
+  - do:
+    - task: successful-job
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: paasmule/curl-ssl-jq
+        run:
+          path: bash
+          args:
+          - -exc
+          - -o
+          - pipefail
+          - |
+            find /lib | tail -n 100
+      on_success:
+        do:
+        - put: teams-alert
+          params:
+            status: success
+    - task: failing-job
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: paasmule/curl-ssl-jq
+        run:
+          path: bash
+          args:
+          - -exc
+          - -o
+          - pipefail
+          - |
+            echo "HoHoHo"
+            sleep 5
+            ls dasfsd
+            false
+      on_failure:
+        do:
+        - put: teams-alert
+          params:
+            status: failure
+    timeout: 5m


### PR DESCRIPTION
What:
Logging implemented in teams, using python to collect event stream of
logging from concourse. This is achieved by setting a watermark in the
log in the python script and collecting data from each event up to that point.
A curl is made to a teams webhook, that sends a message card with
information relating to the concourse, pipeline, job, task, and logs
from said task. We pass in atc_username, atc_password, webhook, proxy
and status to the resource which is used to create a message card to
send to teams.

How to test:
Easiest way to test is to do the other PRs that have been raised for the pipelines that currently have the basic teams notification set up on them, change the pipeline to use the FILPAAS-3855 branch (so they will pull correct docker image) and add...
```
on_success:
        do:
        - put: teams-alert
          params:
            status: success
```
to a task that is currently 'succeeding (will need to be a pipeline that is sending to pager duty/teams already so that it contains the required resource and resource-type (may also help so you can look at implementation of the on-failure task for comparison). make deploy-pipeline, run the job and it then check in concourse that it has passed, then check teams alert channel to see the passing job and its logs.
Could also find a job that runs a lot that has 'failed', and the on_failure task should already be implemented in the FILPAAS-3855 branch for that pipeline, so no changes would need to be made.

Relevant pipeline PRs can be found here:

https://bitbucket.bip.uk.fid-intl.com/projects/FILCF/repos/cf-monitoring-pipeline/pull-requests/46/overview
https://bitbucket.bip.uk.fid-intl.com/projects/FILCF/repos/virgil-pipeline/pull-requests/13/overview
https://bitbucket.bip.uk.fid-intl.com/projects/filcf/repos/infra-monitoring-pipeline/pull-requests/28/overview
https://bitbucket.bip.uk.fid-intl.com/projects/FILCF/repos/concourse-cognisance-pipeline/pull-requests/11/overview
https://bitbucket.bip.uk.fid-intl.com/projects/filcf/repos/dc-control-pipeline/pull-requests/27/overview

Who:
Not Stuart, Piotr or Sushant