### PR TITLE
Fix failing docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.7-alpine
-ENV PACKAGES "bash curl openssl ca-certificates jq vim"
-RUN apk add --update "${PACKAGES}" && rm -rf /var/cache/apk/*
+RUN apk add --no-cache --update bash curl openssl ca-certificates jq vim
 RUN pip install --upgrade pip
 COPY assets/ /opt/resource/
 RUN pip install -r /opt/resource/requirements.txt


### PR DESCRIPTION
It was complaining about:

ERROR: 'bash curl openssl ca-certificates jq vim' is not a valid world dependency, format is name(@tag)([<>~=]version)