### PR TITLE
Boyscout update concourse auth url

### DIFF
--- a/assets/teams_error_capture.py
+++ b/assets/teams_error_capture.py
@@ -15,18 +15,18 @@ def search_ids_names(current_id, accum_dict, plan):
 
     return accum_dict
 
-def main(): 
+def main():
     requests.packages.urllib3.disable_warnings()
 
     # variables are env vars from a 'get' or 'put' concourse container
-    concourse_hostname = sys.argv[1] 
+    concourse_hostname = sys.argv[1]
     concourse_username = sys.argv[2]
     concourse_password = sys.argv[3]
     build_number = sys.argv[4]
 
     # Login
     # OAuth2 token request
-    url = '{0}/sky/token'.format(concourse_hostname)
+    url = '{0}/sky/issuer/token'.format(concourse_hostname)
     payload = {
       'grant_type': 'password',
       'username': concourse_username,

--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -10,9 +10,9 @@ resources:
 - name: teams-alert
   type: teams-notification
   source:
-    webhook_url: <webhook>
-    concourse_username: <username>
-    concourse_password: <password>
+    url: ((webhook))
+    atc_username: ((atc_username))
+    atc_password: ((atc_password))
 
 jobs:
 - name: monitoring-test
@@ -26,7 +26,7 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: paasmule/curl-ssl-jq
+            repository: fidelityinternational/paas-tools-go
         run:
           path: bash
           args:
@@ -46,7 +46,7 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: paasmule/curl-ssl-jq
+            repository: fidelityinternational/paas-tools-go
         run:
           path: bash
           args:


### PR DESCRIPTION
h2.What and why
Updated concourse auth url after recent concourse upgrade to 6.5.0 changed the url to fetch token from. Updated pipeline usage example after recent deprecation of Paasmule.

h2.How
Check diffs and merge