### PR TITLE
PR Truncate logs if they exceed 13500 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Source Configuration
 
 The following fields are required if you want to see erroring Concourse task output in the Teams notification:
 
+- url: Teams webhook url
 - atc_external_url: *Optional* The ATC external URL (if username and password is supplied but not the ATC URL, it will attempt to use the standard in-built ATC_EXTERNAL_URL instead)
 - atc_username: *Optional* ATC username is required if atc_external_url is supplied.
 - atc_password: *Optional* ATC password is required if atc_external_url is supplied.
+- log_max_length: *Optional* Log max length can be configured here. Is necessary as Teams has a character limit on messages received.
 
 Example resource config:
 
@@ -33,14 +35,16 @@ resources:
   type: teams-notification
   source:
     url: ((teams_webhook))
+    atc_external_url: ...
     atc_username: ...
     atc_password: ...
+    log_max_length: ...
 ```
 
 Behaviour
 --------
 
-### Sends alert to teams.
+### Sends alert to teams
 
 Send alert to teams with the configured parameters.
 

--- a/assets/out
+++ b/assets/out
@@ -8,13 +8,13 @@ exec 1>&2 # redirect all output to stderr for logging
 # for jq
 PATH=/usr/local/bin:$PATH
 
-
-
+# To test out script, run `/opt/resource/out < /tmp/resource-in.XXXXXX` using the generated tmp file.
 payload=$(mktemp /tmp/resource-in.XXXXXX)
 
 cat > "${payload}" <&0
 
 webhook_url="$(jq -r '.source.url' < "${payload}")"
+log_max_length="$(jq -r '.source.log_max_length // 19000' < "${payload}")"
 build_status="$(jq -r '(.params.status // null)' < "${payload}")"
 proxy="$(jq -r '(.params.proxy // null)' < "${payload}")"
 atc_username="$(jq -r '.source.atc_username' < "${payload}")"
@@ -38,7 +38,8 @@ if [ "${ATC_EXTERNAL_URL:-}" != "" ] && [ "${atc_username:-}" != "" ] && [ "${at
     "${ATC_EXTERNAL_URL}" \
     "${atc_username}" \
     "${atc_password}" \
-    "${BUILD_ID}")"
+    "${BUILD_ID}" \
+    "${log_max_length}")"
 else
     error_context="No error context possible without valid ATC url and credentials."
 fi
@@ -57,7 +58,6 @@ case "$build_status" in
     exit 1
     ;;
 esac
-
 
 message_summary="${BUILD_PIPELINE_NAME} - ${BUILD_JOB_NAME}"
 message_title_link="${ATC_EXTERNAL_URL}/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}"

--- a/assets/teams_error_capture.py
+++ b/assets/teams_error_capture.py
@@ -23,6 +23,7 @@ def main():
     concourse_username = sys.argv[2]
     concourse_password = sys.argv[3]
     build_number = sys.argv[4]
+    log_max_length = int(sys.argv[5])
 
     # Login
     # OAuth2 token request
@@ -104,7 +105,11 @@ def main():
 
 # messagecards for teams require \n\n for a new line
     output=("\n").join("\n--------------\n".join([task_map[k], v]) for k,v in list(logs.items()))
-    print(json.dumps(output.replace("\n","\n\n")))
+    output = output.replace("\n","\n\n")
+    if len(output) > log_max_length:
+        output = output[:log_max_length] + f'\n\n... truncating error log - message over {log_max_length}'
+
+    print(json.dumps(output))
 
 if __name__ == '__main__':
     main()

--- a/test-pipeline.yml
+++ b/test-pipeline.yml
@@ -13,6 +13,7 @@ resources:
     url: ((webhook))
     atc_username: ((atc_username))
     atc_password: ((atc_password))
+    log_max_length: 13500
 
 jobs:
 - name: monitoring-test


### PR DESCRIPTION
Once the message card exceeds a certain amount of characters, the teams webhook is
unable to curl it without errors complaining of large payload ora 413 error.

We are truncating the error log at 13500 characters (max we could found
we could send) to allow some wiggle room for the other message cards fields,
but are supplying a way to override that value to be included in the pipeline under
the resource-type.source parameters.
Readme and test pipeline updated to reflect new variable added.

h2.How
Check diffs and merge. 