### PR TITLE
If a key in the logs file contains a slash then the taskmap get confused

### DIFF
--- a/assets/teams_error_capture.py
+++ b/assets/teams_error_capture.py
@@ -139,7 +139,6 @@ def main():
     sys.stderr.flush()
 
     try:
-        output = ""
         for event in client.events():
             if event.event == 'end':
                 break
@@ -163,7 +162,7 @@ def main():
       logs.pop(resourceTaskId, None)
 
 # messagecards for teams require \n\n for a new line
-    output=("\n").join("\n--------------\n".join([task_map[k], v]) for k,v in list(logs.items()))
+    output=("\n").join("\n--------------\n".join([task_map[k.split('/')[0]], v]) for k,v in list(logs.items()))
     output = output.replace("\n","\n\n")
     if len(output) > log_max_length:
         output = output[:log_max_length] + f'\n\n... truncating error log - message over {log_max_length}'


### PR DESCRIPTION
We noticed a keyerror can occur when a key in the logs dict contains a
slash.
Hence we remove the slash to allow the processing of the logs dict into
the Teams output message.
The key with slash only seems to occur if the logs contain a get image
log. If they do not it will happiky run through. This fix should
workaround that issue though.